### PR TITLE
Fixing a bug where DNS_IP could not be determined

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     nano \
     vim-nox \
     openssl \
+    bind9-host \
     && rm -rf /var/lib/apt/lists/*
 
 # those are the really necessary packages

--- a/docker-compose-no-nginx-dev.yml
+++ b/docker-compose-no-nginx-dev.yml
@@ -30,6 +30,8 @@ services:
       - net.ipv4.conf.all.src_valid_mark=1
       - net.ipv4.ip_forward=1
     command: /bin/bash /app/init.sh
+    depends_on:
+      - wireguard-webadmin-dns
 
   wireguard-webadmin-cron:
     container_name: wireguard-webadmin-cron

--- a/docker-compose-no-nginx.yml
+++ b/docker-compose-no-nginx.yml
@@ -27,6 +27,8 @@ services:
       - net.ipv4.conf.all.src_valid_mark=1
       - net.ipv4.ip_forward=1
     command: /bin/bash /app/init.sh
+    depends_on:
+      - wireguard-webadmin-dns
 
   wireguard-webadmin-cron:
     container_name: wireguard-webadmin-cron

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - net.ipv4.conf.all.src_valid_mark=1
       - net.ipv4.ip_forward=1
     command: /bin/bash /app/init.sh
+    depends_on:
+      - wireguard-webadmin-dns
 
   wireguard-webadmin-cron:
     container_name: wireguard-webadmin-cron


### PR DESCRIPTION
The "host" command was missing from the main admin container so the script couldn't reliably detect the DNS container's IP. Also, there was no dependency in the docker-compose meaning the DNS container may have been started before the admin container.