### PR TITLE
Expand domain length from 6 to 18 characters

### DIFF
--- a/wgwadmlibrary/tools.py
+++ b/wgwadmlibrary/tools.py
@@ -11,7 +11,7 @@ def is_valid_ip_or_hostname(value):
         pass
     
     # Regex to check valid hostname (RFC 1123)
-    hostname_regex = r'^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}$' 
+    hostname_regex = r'^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,18}$' 
     if re.match(hostname_regex, value):
         return True
     


### PR DESCRIPTION
Fix replacing current 6 character domain check to 18 - which seems to be currently the longest used domain name. I myself use the .network domain which results in an error when changing the 'Public Address'